### PR TITLE
Made item comparison in auction listing optional

### DIFF
--- a/aux-addon.toc
+++ b/aux-addon.toc
@@ -1,7 +1,7 @@
 ## Interface: 11200
 ## Title: aux
 ## Notes: Auction House replacement
-## SavedVariablesPerCharacter: aux_tooltip_value, aux_tooltip_daily, aux_tooltip_merchant_buy, aux_tooltip_merchant_sell, aux_tooltip_disenchant_value, aux_tooltip_disenchant_distribution, aux_tooltip_disenchant_source
+## SavedVariablesPerCharacter: aux_tooltip_value, aux_tooltip_daily, aux_tooltip_merchant_buy, aux_tooltip_merchant_sell, aux_tooltip_disenchant_value, aux_tooltip_disenchant_distribution, aux_tooltip_disenchant_source, aux_tooltip_compare
 ## SavedVariables: aux_scale, aux_datasets, aux_items, aux_item_ids, aux_auctionable_items, aux_merchant_buy, aux_merchant_sell, aux_characters, aux_recent_searches, aux_favorite_searches, aux_post_bid, aux_ignore_owner
 
 libs\inspect.lua

--- a/core/slash.lua
+++ b/core/slash.lua
@@ -32,6 +32,9 @@ function SlashCmdList.AUX(command)
     elseif arguments[1] == 'tooltip' and arguments[2] == 'daily' then
 	    _G.aux_tooltip_daily = not aux_tooltip_daily
         print('tooltip daily ' .. status(aux_tooltip_daily))
+    elseif arguments[1] == 'tooltip' and arguments[2] == 'compare' then
+        _G.aux_tooltip_compare = not aux_tooltip_compare
+        print('tooltip compare ' .. status(aux_tooltip_compare))
     elseif arguments[1] == 'tooltip' and arguments[2] == 'vendor' and arguments[3] == 'buy' then
 	    _G.aux_tooltip_merchant_buy = not aux_tooltip_merchant_buy
         print('tooltip vendor buy ' .. status(aux_tooltip_merchant_buy))
@@ -61,6 +64,7 @@ function SlashCmdList.AUX(command)
 		print('- post bid [' .. status(aux_post_bid) .. ']')
 		print('- tooltip value [' .. status(aux_tooltip_value) .. ']')
 		print('- tooltip daily [' .. status(aux_tooltip_daily) .. ']')
+        print('- tooltip compare [' .. status(aux_tooltip_compare) .. ']')
 		print('- tooltip vendor buy [' .. status(aux_tooltip_merchant_buy) .. ']')
 		print('- tooltip vendor sell [' .. status(aux_tooltip_merchant_sell) .. ']')
 		print('- tooltip disenchant value [' .. status(aux_tooltip_disenchant_value) .. ']')

--- a/util/info.lua
+++ b/util/info.lua
@@ -180,35 +180,37 @@ function M.set_tooltip(itemstring, owner, anchor)
 end
 
 function M.set_shopping_tooltip(slot)
-    local index1, index2 = inventory_index(slot)
-    local tooltips = temp-T
-    if index1 then
-        local tooltip = tooltip('inventory', 'player', index1)
-        if getn(tooltip) > 0 then
-            tinsert(tooltips, tooltip)
+    if _G.aux_tooltip_compare then
+            local index1, index2 = inventory_index(slot)
+        local tooltips = temp-T
+        if index1 then
+            local tooltip = tooltip('inventory', 'player', index1)
+            if getn(tooltip) > 0 then
+                tinsert(tooltips, tooltip)
+            end
         end
-    end
-    if index2 then
-        local tooltip = tooltip('inventory', 'player', index2)
-        if getn(tooltip) > 0 then
-            tinsert(tooltips, tooltip)
+        if index2 then
+            local tooltip = tooltip('inventory', 'player', index2)
+            if getn(tooltip) > 0 then
+                tinsert(tooltips, tooltip)
+            end
         end
-    end
 
-    if tooltips[1] then
-        tinsert(tooltips[1], 1, temp-O('left_text', 'Currently Equipped', 'left_color', temp-A(.5, .5, .5)))
-        ShoppingTooltip1:SetOwner(GameTooltip, 'ANCHOR_NONE')
-        ShoppingTooltip1:SetPoint('TOPLEFT', GameTooltip, 'TOPRIGHT', 0, -10)
-        load_tooltip(ShoppingTooltip1, tooltips[1])
-        ShoppingTooltip1:Show()
-    end
+        if tooltips[1] then
+            tinsert(tooltips[1], 1, temp-O('left_text', 'Currently Equipped', 'left_color', temp-A(.5, .5, .5)))
+            ShoppingTooltip1:SetOwner(GameTooltip, 'ANCHOR_NONE')
+            ShoppingTooltip1:SetPoint('TOPLEFT', GameTooltip, 'TOPRIGHT', 0, -10)
+            load_tooltip(ShoppingTooltip1, tooltips[1])
+            ShoppingTooltip1:Show()
+        end
 
-    if tooltips[2] then
-        tinsert(tooltips[2], 1, temp-O('left_text', 'Currently Equipped', 'left_color', temp-A(.5, .5, .5)))
-        ShoppingTooltip2:SetOwner(ShoppingTooltip1, 'ANCHOR_NONE')
-        ShoppingTooltip2:SetPoint('TOPLEFT', ShoppingTooltip1, 'TOPRIGHT')
-        load_tooltip(ShoppingTooltip2, tooltips[2])
-        ShoppingTooltip2:Show()
+        if tooltips[2] then
+            tinsert(tooltips[2], 1, temp-O('left_text', 'Currently Equipped', 'left_color', temp-A(.5, .5, .5)))
+            ShoppingTooltip2:SetOwner(ShoppingTooltip1, 'ANCHOR_NONE')
+            ShoppingTooltip2:SetPoint('TOPLEFT', ShoppingTooltip1, 'TOPRIGHT')
+            load_tooltip(ShoppingTooltip2, tooltips[2])
+            ShoppingTooltip2:Show()
+        end
     end
 end
 


### PR DESCRIPTION
I added /aux tooltip compare -switch to enable/disable (by default disabled - note that currently this is always on) the item comparison tooltip(s) generated by set_shopping_tooltip - if user has both EquipCompare and aux the overlap looks quite bad.