### PR TITLE
Fix tooltip value for inventory items

### DIFF
--- a/core/tooltip.lua
+++ b/core/tooltip.lua
@@ -170,7 +170,7 @@ end
 function game_tooltip_hooks.SetInventoryItem(unit, slot)
     local link = GetInventoryItemLink(unit, slot)
     if link then
-        extend_tooltip(GameTooltip, link, 1)
+        extend_tooltip(GameTooltip, link, GetInventoryItemCount(unit, slot))
     end
 end
 


### PR DESCRIPTION
Previously, when holding shift while hovering an
inventory item, the total value wouldn't change.
This is because the quantity was always being
passed as 1. Now we pass the actual item count.