### PR TITLE
add color for quality dropdown

### DIFF
--- a/tabs/search/filter.lua
+++ b/tabs/search/filter.lua
@@ -342,7 +342,7 @@ end
 function initialize_quality_dropdown()
     local options = {ALL}
     for i = 0, 4 do
-        tinsert(options, _G['ITEM_QUALITY' .. i .. '_DESC'])
+        tinsert(options, ITEM_QUALITY_COLORS[i].hex .. _G['ITEM_QUALITY' .. i .. '_DESC'])
     end
     quality_dropdown:SetOptions(options)
     quality_dropdown:SetIndex(1)


### PR DESCRIPTION
this will make much faster selection of the desired quality of items, focusing on the color, and not reading the white text
![WoWScrnShot_071521_215656](https://user-images.githubusercontent.com/24303693/125843504-36e62dff-b0f9-4cd2-879f-b15175ee0770.jpg)
