### PR TITLE
fix color for quality dropdown

### DIFF
--- a/gui/core.lua
+++ b/gui/core.lua
@@ -80,15 +80,15 @@ function M.button(parent, text_height)
     highlight:SetAllPoints()
     highlight:SetColorTexture(1, 1, 1, .2)
     button.highlight = highlight
-    do
-        local label = button:CreateFontString()
-        label:SetFont(font, text_height)
-        label:SetAllPoints(button)
-        label:SetJustifyH('CENTER')
-        label:SetJustifyV('CENTER')
-        label:SetTextColor(aux.color.text.enabled())
-        button:SetFontString(label)
-    end
+
+    local label = button:CreateFontString()
+    label:SetFont(font, text_height)
+    label:SetAllPoints(button)
+    label:SetJustifyH('CENTER')
+    label:SetJustifyV('CENTER')
+    label:SetTextColor(aux.color.text.enabled())
+    button:SetFontString(label)
+
     button.default_Enable = button.Enable
     function button:Enable()
         if self:IsEnabled() == 1 then return end
@@ -102,6 +102,7 @@ function M.button(parent, text_height)
         return self:default_Disable()
     end
 
+    button.label = label
     return button
 end
 
@@ -433,10 +434,10 @@ do
                 local item_button = dropdown_item_buttons[i]
                 if not item_button then
                     item_button = button(dropdown_frame, text_height)
-                    item_button:GetFontString():SetJustifyH('LEFT')
+                    item_button.label:SetJustifyH('LEFT')
                     dropdown_item_buttons[i] = item_button
                 else
-                    item_button:GetFontString():SetFont(font, text_height)
+                    item_button.label:SetFont(font, text_height)
                 end
                 if i > #options then
                     item_button:Hide()

--- a/gui/core.lua
+++ b/gui/core.lua
@@ -390,6 +390,7 @@ do
 
         local index, set_index, update_dropdown
         local options = {}
+        local color_table = {}
 
         local editbox = editbox(parent)
 
@@ -406,9 +407,15 @@ do
 
         function set_index(new_index)
             if new_index then
+                local color = color_table[new_index]
                 new_index = max(1, min(#options, new_index))
                 if editbox:GetText() ~= options[new_index] then
                     editbox:SetText(options[new_index])
+                end
+                if color then
+                    editbox.overlay:SetTextColor(color.r, color.g, color.b)
+                else
+                    editbox.overlay:SetTextColor(aux.color.text.enabled())
                 end
             else
                 editbox:SetText('')
@@ -431,6 +438,7 @@ do
             dropdown_frame:SetWidth(width)
             dropdown_frame:SetPoint('TOP', editbox, 'BOTTOM', 0, 0)
             for i = 1, max(#options, #dropdown_item_buttons) do
+                local color = color_table[i]
                 local item_button = dropdown_item_buttons[i]
                 if not item_button then
                     item_button = button(dropdown_frame, text_height)
@@ -445,6 +453,11 @@ do
                     item_button:ClearAllPoints()
                     item_button:SetWidth(width - 4)
                     item_button:SetText(' ' .. options[i])
+                    if color then
+                        item_button.label:SetTextColor(color.r, color.g, color.b)
+                    else
+                        item_button.label:SetTextColor(aux.color.text.enabled())
+                    end
                     if i == 1 then
                         item_button:SetPoint('TOP', editbox, 'BOTTOM', 0, -2)
                     else
@@ -468,6 +481,18 @@ do
             end
         end
 
+        local function set_color_table(new_color_table)
+            --[[
+            Example:
+                table = {
+                    [1] = {r=1,g=1,b=1},
+                    ...
+                    [n] = {r=1,g=1,b=1},
+                }
+            --]]
+            color_table = new_color_table or {}
+        end
+
         editbox.focus_gain = function()
             update_dropdown()
         end
@@ -477,8 +502,9 @@ do
             dropdown_frame:Hide()
         end
 
-        function editbox:SetOptions(new_options)
+        function editbox:SetOptions(new_options, new_color_table)
             options = new_options
+            set_color_table(new_color_table)
             set_index(nil)
             if editbox:HasFocus() then
                 update_dropdown()

--- a/tabs/search/filter.lua
+++ b/tabs/search/filter.lua
@@ -367,9 +367,17 @@ end
 function initialize_quality_dropdown()
     local options = {ALL}
     for i = 0, 4 do
-        tinsert(options, ITEM_QUALITY_COLORS[i].hex .. _G['ITEM_QUALITY' .. i .. '_DESC'])
+        tinsert(options, _G['ITEM_QUALITY' .. i .. '_DESC'])
     end
-    quality_dropdown:SetOptions(options)
+
+    -- recalculate ITEM_QUALITY_COLORS indexes
+    local NEW_ITEM_QUALITY_COLORS = {}
+    tinsert(NEW_ITEM_QUALITY_COLORS, {r = 1, g = 1, b = 1}) -- white for 'ALL' option
+    for i = 0, #ITEM_QUALITY_COLORS do
+        tinsert(NEW_ITEM_QUALITY_COLORS, ITEM_QUALITY_COLORS[i])
+    end
+
+    quality_dropdown:SetOptions(options, NEW_ITEM_QUALITY_COLORS)
     quality_dropdown:SetIndex(1)
 end
 


### PR DESCRIPTION
Previous implementation broke the function of automatic text filling, so I had to rewrite. Now the text is coloring at the time of set this text, and not when you initialize the list items, thereby not breaking the other functionality.

Now you can absolutely for any dropdown, assign the colors table and all the dropdown items will be colored according to the specified table.