### PR TITLE
add packaging from tags

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,26 @@
+name: Package and release
+
+on:
+  push:
+    tags:
+      - '**'
+
+env:
+  GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      # we first have to clone the AddOn project, this is a required step
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # gets git history for changelogs
+
+      - name: Package and release for Burning Crusade Classic
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -g bcc -n "{package-name}-{project-version}"

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,1 @@
+package-as: aux-addon


### PR DESCRIPTION
Since you already store your source code here and tag with corresponding versions I thought it would be nice to distribute the addon itself through github as well. 

Personally, I am trying to move away from curseforge and this would allow providers like wowup to directly pull the addon from github.

Documentation for the Workflow can be found here: https://github.com/BigWigsMods/packager
I only added the very basic workflow I use myself for packaging and publishing a github release but it could easily be extended to support curseforge or wowinterface as well.

Tested it on the fork and it seems to work as expected.

Thanks for your work and the consideration of this PR.

Cheers