### PR TITLE
Add filters disenchant-percent and bid-disenchant-percent

### DIFF
--- a/util/filter.lua
+++ b/util/filter.lua
@@ -149,7 +149,7 @@ M.filters = {
         end
     },
 
-    ['bid-disenchant-profit-percent'] = {
+    ['bid-disenchant-percent'] = {
         input_type = 'number',
         validator = function(pct)
             return function(auction_record)
@@ -171,7 +171,7 @@ M.filters = {
         end
     },
 
-    ['disenchant-profit-percent'] = {
+    ['disenchant-percent'] = {
         input_type = 'number',
         validator = function(pct)
             return function(auction_record)

--- a/util/filter.lua
+++ b/util/filter.lua
@@ -149,6 +149,17 @@ M.filters = {
         end
     },
 
+    ['bid-disenchant-profit-pct'] = {
+        input_type = 'number',
+        validator = function(pct)
+            return function(auction_record)
+                local item_info = info.item(auction_record.item_id)
+                local disenchant_value = item_info and disenchant.value(item_info.slot, item_info.quality, item_info.level)
+                return disenchant_value and auction_record.bid_price / disenchant_value * 100 <= pct
+            end
+        end
+    },
+
     ['disenchant-profit'] = {
         input_type = 'money',
         validator = function(amount)
@@ -156,6 +167,17 @@ M.filters = {
                 local item_info = info.item(auction_record.item_id)
                 local disenchant_value = item_info and disenchant.value(auction_record.item_id, item_info.slot, item_info.quality, item_info.level)
                 return auction_record.buyout_price > 0 and disenchant_value and disenchant_value - auction_record.buyout_price >= amount
+            end
+        end
+    },
+
+    ['disenchant-profit-pct'] = {
+        input_type = 'number',
+        validator = function(pct)
+            return function(auction_record)
+                local item_info = info.item(auction_record.item_id)
+                local disenchant_value = item_info and disenchant.value(item_info.slot, item_info.quality, item_info.level)
+                return auction_record.buyout_price > 0 and disenchant_value and auction_record.buyout_price / disenchant_value * 100 <= pct
             end
         end
     },

--- a/util/filter.lua
+++ b/util/filter.lua
@@ -149,7 +149,7 @@ M.filters = {
         end
     },
 
-    ['bid-disenchant-profit-pct'] = {
+    ['bid-disenchant-profit-percent'] = {
         input_type = 'number',
         validator = function(pct)
             return function(auction_record)
@@ -171,7 +171,7 @@ M.filters = {
         end
     },
 
-    ['disenchant-profit-pct'] = {
+    ['disenchant-profit-percent'] = {
         input_type = 'number',
         validator = function(pct)
             return function(auction_record)


### PR DESCRIPTION
Currently, aux has the filters disenchant-profit and bid-disenchant-profit for finding disenchanting deals. However, these filters take a money threshold as a parameter, which means that a large parameter value cuts off low level disenchanting deals and a small parameter value shows high level items with too tight margins.

I propose adding disenchant-percent and bid-disenchant-percent that take a percentage threshold as a parameter instead.