### PR TITLE
[classic-era] Cherry-pick: Use "MIDDLE" in SetJustifyV calls

### DIFF
--- a/gui/auction_listing.lua
+++ b/gui/auction_listing.lua
@@ -1067,7 +1067,7 @@ function M.new(parent, rows, columns)
             cell.text = text
             text:SetFont(gui.font, min(14, rt.ROW_HEIGHT))
             text:SetJustifyH(column.align or 'LEFT')
-            text:SetJustifyV('CENTER')
+            text:SetJustifyV('MIDDLE')
             text:SetPoint('TOPLEFT', 1, -1)
             text:SetPoint('BOTTOMRIGHT', -1, 1)
             cell:SetHeight(rt.ROW_HEIGHT)

--- a/gui/core.lua
+++ b/gui/core.lua
@@ -85,7 +85,7 @@ function M.button(parent, text_height)
     label:SetFont(font, text_height)
     label:SetAllPoints(button)
     label:SetJustifyH('CENTER')
-    label:SetJustifyV('CENTER')
+    label:SetJustifyV('MIDDLE')
     label:SetTextColor(aux.color.text.enabled())
     button:SetFontString(label)
 
@@ -135,7 +135,7 @@ do
         tab.text = tab:CreateFontString()
         tab.text:SetAllPoints()
         tab.text:SetJustifyH('CENTER')
-        tab.text:SetJustifyV('CENTER')
+        tab.text:SetJustifyV('MIDDLE')
         tab.text:SetFont(font, font_size.large)
         tab:SetFontString(tab.text)
 

--- a/gui/listing.lua
+++ b/gui/listing.lua
@@ -210,7 +210,7 @@ local methods = {
         local text = cell:CreateFontString()
         cell.text = text
         text:SetFont(gui.font, ROW_TEXT_SIZE)
-        text:SetJustifyV('CENTER')
+        text:SetJustifyV('MIDDLE')
         text:SetPoint('TOPLEFT', 1, -1)
         text:SetPoint('BOTTOMRIGHT', -1, 1)
         cell:SetHeight(ROW_HEIGHT)


### PR DESCRIPTION
Cherry-pick [the commit](https://github.com/shirsig/aux-addon/commit/0f5d091306db60de799d3b2ab122917fa9ec8eb6) to change `SetJustifyV` to use middle to resolve issues in new SoD WoW v1.15.3.55515