### PR TITLE
Classic Era, 1.15.7: Update use of `PostAuction` to set confirmation param

### DIFF
--- a/tabs/post/core.lua
+++ b/tabs/post/core.lua
@@ -253,7 +253,7 @@ function post_auction()
         end
     end
 
-    PostAuction(start_price, buyout_price, duration, stack_size, stack_count)
+    PostAuction(start_price, buyout_price, duration, stack_size, stack_count, true)
 
     posting = stack_count == 1 and 'single' or 'multi'
     aux.coro_thread(function()


### PR DESCRIPTION
Fixes #385

Looking at https://github.com/Gethe/wow-ui-source/tree/classic_era for inspiration, it seems the function still supports stack size and count, but now hard requires the additional boolean `warningAcknowledged` parameter. Simply setting it makes it work.

Tested on classic era 20th anniversary realms, posting single items, full stacks and various combinations of stack size and count: All good.
