### PR TITLE
Add purchase preview counter

### DIFF
--- a/frame.lua
+++ b/frame.lua
@@ -15,7 +15,7 @@ do
 	local frame = CreateFrame('Frame', 'aux_frame', UIParent, 'BackdropTemplate')
 	tinsert(UISpecialFrames, 'aux_frame')
 	gui.set_window_style(frame)
-	gui.set_size(frame, 768, 447)
+	gui.set_size(frame, 850, 447)
 	frame:SetPoint('LEFT', 100, 0)
 	frame:SetToplevel(true)
 	frame:SetMovable(true)

--- a/tabs/bids/core.lua
+++ b/tabs/bids/core.lua
@@ -95,5 +95,5 @@ function update_bought_count_display()
     if bought_count_label then
         bought_count_label:SetText(bought_count > 0 and (bought_count .. ' bought') or '')
     end
-    DEFAULT_CHAT_FRAME:AddMessage('<aux> Gekauft: ' .. bought_count)
+    DEFAULT_CHAT_FRAME:AddMessage('<aux> Bought: ' .. bought_count)
 end

--- a/tabs/bids/frame.lua
+++ b/tabs/bids/frame.lua
@@ -51,3 +51,15 @@ do
     btn:SetScript('OnClick', function() place_bid(true) end)
     buyout_button = btn
 end
+
+do
+    local bought_label = buyout_button:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall')
+    bought_label:SetPoint('BOTTOM', buyout_button, 'BOTTOM', 0, 2)
+    bought_label:SetText('')
+    bought_count_label = bought_label
+    
+    local qty_label = buyout_button:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall')
+    qty_label:SetPoint('LEFT', bought_label, 'RIGHT', 5, 0)
+    qty_label:SetText('')
+    quantity_label = qty_label
+end

--- a/tabs/search/frame.lua
+++ b/tabs/search/frame.lua
@@ -14,6 +14,14 @@ FILTER_SPACING = 27
 frame = CreateFrame('Frame', nil, aux.frame)
 frame:SetAllPoints()
 frame:SetScript('OnUpdate', on_update)
+frame:SetScript('OnHide', function()
+    if search_bought_count_label then
+        search_bought_count_label:SetText('')
+    end
+    if search_quantity_label then
+        search_quantity_label:SetText('')
+    end
+end)
 frame:Hide()
 
 frame.filter = gui.panel(frame)
@@ -184,6 +192,17 @@ do
         while tremove(current_search().records) do end
         current_search().table:SetDatabase()
     end)
+    clear_button = btn
+    
+    local bought_label = btn:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall')
+    bought_label:SetPoint('LEFT', btn, 'RIGHT', 5, 0)
+    bought_label:SetText('')
+    search_bought_count_label = bought_label
+    
+    local qty_label = btn:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall')
+    qty_label:SetPoint('LEFT', bought_label, 'RIGHT', 15, 0)
+    qty_label:SetText('')
+    search_quantity_label = qty_label
 end
 do
     local btn = gui.button(frame.saved)

--- a/tabs/search/results.lua
+++ b/tabs/search/results.lua
@@ -41,7 +41,7 @@ function update_search_bought_count_display()
         search_bought_count_label:SetText(search_bought_count > 0 and (search_bought_count .. ' bought') or '')
     end
     if search_bought_count > 0 then
-        DEFAULT_CHAT_FRAME:AddMessage('<aux> Purchased: ' .. search_bought_count)
+        DEFAULT_CHAT_FRAME:AddMessage('<aux> Bought: ' .. search_bought_count)
     end
 end
 


### PR DESCRIPTION
### What’s new
This PR adds a small **purchase preview counter** to the AUX addon UI.

The counter shows:
- **Total items already bought**
- **How many items would be bought with the *next* purchase action** (preview)

Example:
<img width="648" height="60" alt="image" src="https://github.com/user-attachments/assets/de91efac-0ee9-479e-aa3d-9a5168dc874a" />

In this case, the next Buyout would purchase **1 additional item**, resulting in a total of 5.

The counter is displayed next to the existing **Bid / Buyout / Clear** buttons for immediate visibility.

### Why this change
When buying stackable items or repeatedly interacting with the auction UI, it’s not always obvious how many items the next action will actually purchase.

This preview helps avoid accidental over- or under-buying and makes purchasing decisions more transparent at a glance.

This was originally implemented for personal use in a fork, but turned out to be genuinely useful during normal gameplay — so I decided to contribute it upstream.

### Implementation notes
- Lightweight UI addition
- Purely informational (no behavior changes)
- Automatically updates based on the next purchase action
- No impact on existing AUX logic
